### PR TITLE
Update DofMapPlotter to recent FEniCS versions

### DIFF
--- a/fenicstools/DofMapPlotter.py
+++ b/fenicstools/DofMapPlotter.py
@@ -36,6 +36,7 @@ class DofMapPlotter(object):
         # Analyze the space V
         self.V = V
         self.dofmaps = extract_dofmaps(self.V)
+        self.elements = extract_elements(self.V)
         self.bounds = bounds(self.V)
 
         # Rewrite default plotting options if they are provided by user

--- a/fenicstools/dofmapplotter/__init__.py
+++ b/fenicstools/dofmapplotter/__init__.py
@@ -1,2 +1,2 @@
-from common import extract_dofmaps, bounds, is_function_space
+from common import extract_dofmaps, extract_elements, bounds, is_function_space
 from dofmapplot import DofMapPlot

--- a/fenicstools/dofmapplotter/common.py
+++ b/fenicstools/dofmapplotter/common.py
@@ -83,9 +83,9 @@ def signature(V):
 def extract_dofmaps(V):
     '''Extract dofmap of every component of V.
     S, space whose signature is 0 has only one dofmap
-    V, space whose signature is 3, has 3 dofmaps
+    V, space whose signature is 3, has 3 dofmaps V.sub(i), i = 0, 1, 2
     M=[S, V], space whose signature is [0, 3] has four dofmaps, M.sub(0) and
-    (M.sub(0)).sub(i), i = 0, 1, 2'''
+    (M.sub(1)).sub(i), i = 0, 1, 2'''
     signature_ = signature(V)
     if type(signature_) is int:
         if signature_ == 0:
@@ -99,6 +99,26 @@ def extract_dofmaps(V):
                 Vi = V.sub(i)
                 dofmaps += extract_dofmaps(Vi)
             return dofmaps
+            
+def extract_elements(V):
+    '''Extract element of every component of V.
+    S, space whose signature is 0 has only one element
+    V, space whose signature is 3, has 3 elements V.sub(i).element(), i = 0, 1, 2
+    M=[S, V], space whose signature is [0, 3] has four dofmaps, M.sub(0) and
+    (M.element().sub(1)).sub(i), i = 0, 1, 2'''
+    signature_ = signature(V)
+    if type(signature_) is int:
+        if signature_ == 0:
+            return [V.element()]
+        else:
+            return [V.sub(i).element() for i in range(signature_)]
+    else:
+        if type(signature_) is list:
+            elements = []
+            for i in range(len(signature_)):
+                Vi = V.sub(i)
+                elements += extract_elements(Vi)
+            return elements
 
 
 def flat_signature(V):

--- a/fenicstools/dofmapplotter/dofhandler.py
+++ b/fenicstools/dofmapplotter/dofhandler.py
@@ -4,9 +4,10 @@ __copyright__ = 'Copyright (C) 2013 ' + __author__
 __license__ = 'GNU Lesser GPL version 3 or any later version'
 
 from dofmaphandler import DofMapHandler
-from common import x_to_str, subspace_index
+from common import x_to_str, subspace_index, extract_elements
 from dolfin import Cell
 import time
+import numpy as np
 
 
 class DofHandler(DofMapHandler):
@@ -30,6 +31,7 @@ class DofHandler(DofMapHandler):
         # See which dofmaps will be plotted and which subspaces are used
         self.component = options['component']
         self.dofmaps = dmp.dofmaps
+        self.elements = dmp.elements
         self.bounds = dmp.bounds
         # Get ownership range. To be used with global ordering scheme
         self.first_dof = self.dofmaps[0].ownership_range()[0]
@@ -137,11 +139,12 @@ class DofHandler(DofMapHandler):
         changed_labels = []
         order = self.order
         first_dof = self.first_dof
-
+        
         for i, j in enumerate(self.component):
             cell = Cell(self.mesh, cell_index)
             dofs = self.dofmaps[j].cell_dofs(cell_index)
-            dofs_x = self.dofmaps[j].tabulate_coordinates(cell)
+            dofs_x = np.zeros((len(dofs), self.mesh.topology().dim()))
+            self.elements[j].tabulate_dof_coordinates(cell, dofs_x)
             for dof, dof_x in zip(dofs, dofs_x):
                 dof_x_str = x_to_str(dof_x)
                 # Append to change if dof position was not plotted yet


### PR DESCRIPTION
Dear fenicstools developers,

Today I was trying to use DofMapPlotter with a recent FEniCS version (commit 83a7cb4) but apparently dofmap.tabulate_coordinates was removed as of dolfin commit ad26cbc. 
I try to update fenicstools to the new FEniCS interface in this pull request. I have successfully tested the pull request with the examples on the wiki/DofMapPlotter page.

The third example on the wiki page should also be slightly updated. This is the version I tested
```
from dolfin import *
from fenicstools import DofMapPlotter

mesh = RectangleMesh(Point(0, 0), Point(1, 1), 4, 4)

V = VectorElement('CG', mesh.ufl_cell(), 2)
Q = FiniteElement('CG', mesh.ufl_cell(), 1)
M = FunctionSpace(mesh, MixedElement([V, Q]))

dmp = DofMapPlotter(M)
dmp.plot()       # All dofs of M
dmp.plot(sub=0)  # Dofs of M that belong to V
dmp.plot(sub=1)  # Dofs of M that belong to Q
dmp.show()
```

Thanks for your efforts,
Francesco
