### PR TITLE
Fix of functionality in relocate due to DOLFIN issue #737

### DIFF
--- a/demo/CRInterpolation.py
+++ b/demo/CRInterpolation.py
@@ -8,7 +8,7 @@ x[:] = (x - 0.5) * 2
 x[:] = 0.5*(cos(pi*(x-1.) / 2.) + 1.)
 
 CG = VectorFunctionSpace(mesh, 'CG', 1)
-u = interpolate(Expression(("sin(2*pi*x[0])", "cos(3*pi*x[1])")), CG)
+u = interpolate(Expression(("sin(2*pi*x[0])", "cos(3*pi*x[1])"), degree=3), CG)
 
 C = divergence_matrix(mesh)
 DG = FunctionSpace(mesh, 'DG', 0)

--- a/demo/Probe.py
+++ b/demo/Probe.py
@@ -11,7 +11,7 @@ Vv = VectorFunctionSpace(mesh, 'CG', 1)
 W = V * Vv
 
 # Just create some random data to be used for probing
-w0 = interpolate(Expression(('x[0]', 'x[1]', 'x[2]', 'x[1]*x[2]')), W)
+w0 = interpolate(Expression(('x[0]', 'x[1]', 'x[2]', 'x[1]*x[2]'), degree=2), W)
 
 x = array([[1.5, 0.5, 0.5], [0.2, 0.3, 0.4], [0.8, 0.9, 1.0]])
 p = Probes(x.flatten(), W)

--- a/demo/StructuredGrid.py
+++ b/demo/StructuredGrid.py
@@ -8,12 +8,12 @@ V = FunctionSpace(mesh, 'CG', 1)
 Vv = VectorFunctionSpace(mesh, 'CG', 1)
 W = V * Vv
 
-x0 = interpolate(Expression('x[0]'), V)
-y0 = interpolate(Expression('x[1]'), V)
-z0 = interpolate(Expression('x[2]'), V)
-s0 = interpolate(Expression('exp(-(pow(x[0]-0.5, 2)+ pow(x[1]-0.5, 2) + pow(x[2]-0.5, 2)))'), V)
-v0 = interpolate(Expression(('x[0]', '2*x[1]', '3*x[2]')), Vv)
-w0 = interpolate(Expression(('x[0]', 'x[1]', 'x[2]', 'x[1]*x[2]')), W)
+x0 = interpolate(Expression('x[0]', degree=1), V)
+y0 = interpolate(Expression('x[1]', degree=1), V)
+z0 = interpolate(Expression('x[2]', degree=1), V)
+s0 = interpolate(Expression('exp(-(pow(x[0]-0.5, 2)+ pow(x[1]-0.5, 2) + pow(x[2]-0.5, 2)))', degree=3), V)
+v0 = interpolate(Expression(('x[0]', '2*x[1]', '3*x[2]'), degree=3), Vv)
+w0 = interpolate(Expression(('x[0]', 'x[1]', 'x[2]', 'x[1]*x[2]'), degree=3), W)
 
 # 3D box
 origin = [0.25, 0.25, 0.25]               # origin of box

--- a/demo/WeightedDivergence.py
+++ b/demo/WeightedDivergence.py
@@ -7,8 +7,8 @@ from fenicstools import weighted_gradient_matrix
 set_log_level(WARNING)
 
 # Exact u and its divergence
-u_ = Expression(('sin(pi*x[0])', 'cos(2*pi*x[1])'))
-divu_ = Expression('pi*(cos(pi*x[0]) - 2*sin(2*pi*x[1]))')
+u_ = Expression(('sin(pi*x[0])', 'cos(2*pi*x[1])'), degree=3)
+divu_ = Expression('pi*(cos(pi*x[0]) - 2*sin(2*pi*x[1]))', degree=3)
 
 
 def divergence_test(mesh):

--- a/demo/demo_GaussDivergence_2d.py
+++ b/demo/demo_GaussDivergence_2d.py
@@ -56,19 +56,19 @@ mesh_types['UnitSquareMesh'] = [UnitSquareMesh(N, N) for N in Ns]
 # Create a dicionary of u, divu for u scalar, vector, tensor
 test_cases = {}
 
-u_exact = Expression('sin(pi*x[0]*x[1])')
+u_exact = Expression('sin(pi*x[0]*x[1])', degree=3)
 divu_exact = Expression(('cos(pi*x[0]*x[1])*pi*x[1]',
-                         'cos(pi*x[0]*x[1])*pi*x[0]'))
+                         'cos(pi*x[0]*x[1])*pi*x[0]'), degree=3)
 test_cases['Scalar'] = [u_exact, divu_exact]
 
-u_exact = Expression(('sin(pi*x[0])', 'cos(2*pi*x[1])'))
-divu_exact = Expression('pi*(cos(pi*x[0]) - 2*sin(2*pi*x[1]))')
+u_exact = Expression(('sin(pi*x[0])', 'cos(2*pi*x[1])'), degree=3)
+divu_exact = Expression('pi*(cos(pi*x[0]) - 2*sin(2*pi*x[1]))', degree=3)
 test_cases['Vector'] = [u_exact, divu_exact]
 
 u_exact = Expression((('sin(pi*x[0])', 'cos(pi*x[1])'),
-                      ('-cos(pi*x[0])', 'sin(2*pi*x[1])')))
+                      ('-cos(pi*x[0])', 'sin(2*pi*x[1])')), degree=3)
 divu_exact = Expression(('cos(pi*x[0])*pi - sin(pi*x[1])*pi',
-                         'sin(pi*x[0])*pi + cos(2*pi*x[1])*2*pi'))
+                         'sin(pi*x[0])*pi + cos(2*pi*x[1])*2*pi'), degree=3)
 test_cases['Tensor'] = [u_exact, divu_exact]
 
 # Go through the combinations

--- a/demo/demo_GaussDivergence_3d.py
+++ b/demo/demo_GaussDivergence_3d.py
@@ -41,23 +41,23 @@ meshes = [UnitCubeMesh(N, N, N) for N in [4, 8, 16,  32]]
 # Create a dicionary of u, divu for u scalar, vector, tensor
 test_cases = {}
 
-u_exact = Expression('sin(pi*x[0]*x[1]*x[2])')
+u_exact = Expression('sin(pi*x[0]*x[1]*x[2])', degree=3)
 divu_exact = Expression(('cos(pi*x[0]*x[1]*x[2])*pi*x[1]*x[2]',
                          'cos(pi*x[0]*x[1]*x[2])*pi*x[0]*x[2]',
-                         'cos(pi*x[0]*x[1]*x[2])*pi*x[0]*x[1]'))
+                         'cos(pi*x[0]*x[1]*x[2])*pi*x[0]*x[1]'), degree=3)
 test_cases['Scalar'] = [u_exact, divu_exact]
 
-u_exact = Expression(('sin(pi*x[0])', 'cos(2*pi*x[1])', 'exp(-x[2]*x[2])'))
+u_exact = Expression(('sin(pi*x[0])', 'cos(2*pi*x[1])', 'exp(-x[2]*x[2])'), degree=3)
 divu_exact = \
-    Expression('pi*(cos(pi*x[0]) - 2*sin(2*pi*x[1])) - 2*exp(-x[2]*x[2])*x[2]')
+    Expression('pi*(cos(pi*x[0]) - 2*sin(2*pi*x[1])) - 2*exp(-x[2]*x[2])*x[2]', degree=3)
 test_cases['Vector'] = [u_exact, divu_exact]
 
 u_exact = Expression((('sin(pi*x[0]*x[1]*x[2])', '0', '0'),
                       ('0', 'sin(pi*x[0]*x[1]*x[2])', '0'),
-                      ('0', '0', 'sin(pi*x[0]*x[1]*x[2])')))
+                      ('0', '0', 'sin(pi*x[0]*x[1]*x[2])')), degree=3)
 divu_exact = Expression(('cos(pi*x[0]*x[1]*x[2])*pi*x[1]*x[2]',
                          'cos(pi*x[0]*x[1]*x[2])*pi*x[0]*x[2]',
-                         'cos(pi*x[0]*x[1]*x[2])*pi*x[0]*x[1]'))
+                         'cos(pi*x[0]*x[1]*x[2])*pi*x[0]*x[1]'), degree=3)
 
 test_cases['Tensor'] = [u_exact, divu_exact]
 

--- a/demo/demo_LagrangianParticles.py
+++ b/demo/demo_LagrangianParticles.py
@@ -11,7 +11,8 @@ particle_positions = RandomCircle([0.5, 0.75], 0.15).generate([100, 100])
 
 V = VectorFunctionSpace(mesh, 'CG', 1)
 u = interpolate(Expression(("-2*sin(pi*x[1])*cos(pi*x[1])*pow(sin(pi*x[0]),2)",
-                            "2*sin(pi*x[0])*cos(pi*x[0])*pow(sin(pi*x[1]),2)")),
+                            "2*sin(pi*x[0])*cos(pi*x[0])*pow(sin(pi*x[1]),2)"),
+                            degree=3),
                 V)
 lp = LagrangianParticles(V)
 lp.add_particles(particle_positions)

--- a/demo/test_weight_grad.py
+++ b/demo/test_weight_grad.py
@@ -4,11 +4,11 @@ from math import log as ln
 
 set_log_level(WARNING)
 
-f = Expression('5*pi*pi*sin(2*pi*x[0])*sin(pi*x[1])')
+f = Expression('5*pi*pi*sin(2*pi*x[0])*sin(pi*x[1])', degree=3)
 
-u_ = Expression('sin(2*pi*x[0])*sin(pi*x[1])')
+u_ = Expression('sin(2*pi*x[0])*sin(pi*x[1])', degree=3)
 gradu_ = Expression(('cos(2*pi*x[0])*2*pi*sin(pi*x[1])',\
-                     'sin(2*pi*x[0])*cos(pi*x[1])*pi'))
+                     'sin(2*pi*x[0])*cos(pi*x[1])*pi'), degree=3)
 
 def foo(mesh, family, degree):
     V = FunctionSpace(mesh, family, 1)

--- a/fenicstools/LagrangianParticles.py
+++ b/fenicstools/LagrangianParticles.py
@@ -51,9 +51,11 @@ class CellWithParticles(df.Cell):
         # Make the cell aware of its neighbors; neighbor cells are cells
         # connected to this one by vertices
         tdim = mesh.topology().dim()
+
+        neighbors = sum((vertex.entities(tdim).tolist() for vertex in df.vertices(self)), [])
+        neighbors = set(neighbors) - set([cell_id])   # Remove self
         self.neighbors = map(lambda neighbor_index: df.Cell(mesh, neighbor_index), 
-                             sum((vertex.entities(tdim).tolist()
-                                  for vertex in df.vertices(self)), []))
+                             neighbors)
 
     def __add__(self, particle):
         'Add single particle to cell.'


### PR DESCRIPTION
Due to [ill-defined](https://bitbucket.org/fenics-project/dolfin/issues/737/cell-to-cell-connectivity-broken) cell-cell connectivity the iteration in [relocate](https://github.com/mikaem/fenicstools/blob/master/fenicstools/LagrangianParticles.py#L244) just checks the cell itself. With this PR the loop goes over the patch defined by cell-vertex-cell connectivity